### PR TITLE
Identify field names of TypeGpuBillboardExpression (RE4)

### DIFF
--- a/re4/efx_structs.json
+++ b/re4/efx_structs.json
@@ -9061,72 +9061,72 @@
           "FlagTarget": "14"
         },
         {
-          "Name": "colorR",
+          "Name": "Color",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "colorG",
+          "Name": "ColorAlpha",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "colorB",
+          "Name": "ColorRange",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "colorA",
+          "Name": "ColorRangeAlpha",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "colorRate",
+          "Name": "ColorRate_EmissionRate_ContrastRate_InnerIntensity_MultiplyColorRate",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "alpha2",
+          "Name": "BackIntensity_OuterIntensity_MultiplyBlackRate",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "particleSize",
+          "Name": "SizeScalar",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "particleSizeRand",
+          "Name": "SizeScalarRange",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "unkn9",
+          "Name": "SizeX",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "unkn10",
+          "Name": "SizeXRange",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "unkn11",
+          "Name": "SizeY",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "unkn12",
+          "Name": "SizeYRange",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "unkn13",
+          "Name": "OffsetX",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },
         {
-          "Name": "unkn14",
+          "Name": "OffsetY",
           "FieldType": "S32",
           "Classname": "ReeLib.Efx.Structs.Common.ExpressionAssignType"
         },


### PR DESCRIPTION
The first 6 fields are part of a certain `BlendTypeExpressionList` (I haven't seen that anywhere in the resources, only the EXE)

```
1- Color
2- ColorAlpha
3- ColorRange
4- ColorRangeAlpha
5- ColorRate_EmissionRate_ContrastRate_InnerIntensity_MultiplyColorRate (yep, that whole long name)
6- BackIntensity_OuterIntensity_MultiplyBlackRate
```

Before serializing, it looks like the function is prepending those fields before `GpuBillboardExpressionList`'s 8 fields, using the function belonging to `BlendTypeExpressionList`.

Then come the 8 fields belonging to `GpuBillboardExpressionList`:

```
7- SizeScalar
8- SizeScalarRange
9- SizeX
10- SizeXRange
11- SizeY
12- SizeYRange
13- OffsetX
14- OffsetY
```